### PR TITLE
Improves compatibility with js bundlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./angular-material-calendar.js');
+module.exports = "materialCalendar";

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "md-calendar",
     "ng-calendar"
   ],
-  "main": "angular-material-calendar.js",
+  "main": "index.js",
   "scripts": {
     "test": "karma start --single-run && gulp test"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "md-calendar",
     "ng-calendar"
   ],
-  "main": "gulpfile.js",
+  "main": "angular-material-calendar.js",
   "scripts": {
     "test": "karma start --single-run && gulp test"
   },


### PR DESCRIPTION
Tools like browserify look for the main entry file in package.js.
With this minor update, you can now just use something along the lines of

```javascript
import ngMaterial from 'angular-material'
import ngSanitize from 'angular-sanitize'
import ngMdCalendar from 'angular-material-calendar'
```
or
```javascript
var ngMaterial = require('angular-material')
var ngSanitize = require('angular-sanitize')
var ngMdCalendar = require('angular-material-calendar')
```
and then, when creating your app module instance:
```javascript
angular.module('my-app', [ngMaterial, ngSanitize, ngMdCalendar])
```