### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It's lightweight at ~2.1 kB, and has a lot of configurability.
 ### RawGit
 
 ```html
-<script src="https://cdn.rawgit.com/bradberger/angular-material-calendar/master/dist/angular-material-calendar.js"></script>
+<script src="https://cdn.combinatronics.com/bradberger/angular-material-calendar/master/dist/angular-material-calendar.js"></script>
 ```
 
 ### Bower


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.